### PR TITLE
US-001: GitHub Issues Integration & Triage System

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug Report
+about: Report a bug in the Product OS Framework
+title: '[Bug]: '
+labels: triage
+assignees: ''
+---
+
+## Problem Statement
+
+<!-- What is the bug? What goes wrong? -->
+
+(Required) Describe the bug clearly. Who or what is affected?
+
+## Expected Behavior
+
+<!-- What should happen instead? -->
+
+(Required) What should happen when the bug is fixed?
+
+## Steps to Reproduce
+
+<!-- How can maintainers reproduce the issue? -->
+
+1.
+2.
+3.
+
+## Environment
+
+<!-- e.g. Node version, OS, prd-cli version -->
+
+- Node: 
+- OS: 
+- prd-cli / Product OS: 
+
+## Additional Context
+
+<!-- Logs, screenshots, config snippets -->
+
+(Optional)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement for the Product OS Framework
+title: '[Feature]: '
+labels: triage
+assignees: ''
+---
+
+## Problem Statement
+
+<!-- What problem does this solve? Who is affected? -->
+
+(Required) Describe the problem or opportunity. Be specific.
+
+## Expected Behavior
+
+<!-- What should happen when this is implemented? -->
+
+(Required) Describe what you want to see. Include acceptance criteria if you have them.
+
+## Current Behavior / Workaround
+
+<!-- What happens today? How do you work around it? -->
+
+(Optional) Helps maintainers understand the gap.
+
+## Additional Context
+
+<!-- Links, screenshots, examples from other products -->
+
+(Optional)

--- a/CURSOR_SLASH_COMMANDS.md
+++ b/CURSOR_SLASH_COMMANDS.md
@@ -41,11 +41,12 @@ All commands assume:
 **Recommended command name:** `/create`  
 **Alternative names:** `/story-create`, `/prd-create`  
 **Typical usage:**  
-`/create "Add email notifications" @project/backlog.md`
+`/create "Add email notifications" @project/backlog.md`  
+`/create from #123 @project/backlog.md` — create a story from GitHub Issue #123 (use the Issue’s title and body as the PRD foundation and set `source_issue` in the story).
 
 ### Description (for Cursor UI)
 
-> Create and refine a new story (US-XXX) from a short description, update backlog, and verify the PRD using PROCESS.md.
+> Create and refine a new story (US-XXX) from a short description or from a GitHub Issue, update backlog, and verify the PRD using PROCESS.md.
 
 ### Prompt (system prompt to paste into Cursor)
 
@@ -58,21 +59,25 @@ Goal:
 
 Instructions:
 1. Read PROCESS.md and focus on the Phase 1 (/create) section.
-2. Read product-docs/README.md to understand the workspace and how global story IDs work.
-3. Read the referenced backlog file (e.g. {project}/backlog.md) to understand existing stories.
-4. Determine the next available global ID (US-XXX) using README.md and/or backlog.md.
-5. Create or update the story file {project}/US-XXX.md using the required YAML frontmatter and sections from PROCESS.md.
-6. Drive an iterative conversation with the user to refine:
+2. If the user’s message includes an Issue reference (e.g. “from #123”, “from issue #123”, “based on #123”):
+   - Treat that GitHub Issue as the primary input. Read the Issue’s title and body (e.g. from the repo’s Issues, or from context the user provides).
+   - Use the Issue content to prefill the PRD: map “Problem Statement” and “Expected Behavior” (or similar) from the Issue into the story’s Goal, Problem Statement, and Acceptance Criteria. If the user did not paste the Issue body, ask them to paste it or confirm you have the right Issue.
+   - In the story file’s YAML frontmatter, set source_issue: "#123" (or the actual issue number) so the story is traceable to the Issue.
+3. Read product-docs/README.md to understand the workspace and how global story IDs work.
+4. Read the referenced backlog file (e.g. {project}/backlog.md) to understand existing stories.
+5. Determine the next available global ID (US-XXX) using README.md and/or backlog.md.
+6. Create or update the story file {project}/US-XXX.md using the required YAML frontmatter and sections from PROCESS.md (prefilled from the Issue when applicable).
+7. Drive an iterative conversation with the user to refine:
    - Problem statement, users, and goals
    - Scope, behavior, and non-goals
    - Acceptance criteria (AC), edge cases, non-functional requirements (NFRs)
-7. Run a PRD verification pass as described in PROCESS.md:
+8. Run a PRD verification pass as described in PROCESS.md:
    - Identify gaps
    - Propose concrete fixes
    - Apply or leave for manual edits, based on user choice
-8. Extract features and dev tasks if the process calls for it.
-9. Update {project}/backlog.md and any "next ID" registry so the story is tracked.
-10. When the PRD is ready, summarize:
+9. Extract features and dev tasks if the process calls for it.
+10. Update {project}/backlog.md and any "next ID" registry so the story is tracked.
+11. When the PRD is ready, summarize:
     - Story ID and title
     - Key AC and NFRs
     - Features and dev tasks
@@ -82,6 +87,7 @@ Always:
 - Keep edits within the product-docs repo.
 - Use specific, testable acceptance criteria.
 - Ask for clarification instead of inventing product decisions.
+- When the story was created from an Issue (source_issue set), remind the user to update the GitHub Issue: remove label "triage" and add label "story-created" so the issue lifecycle stays in sync (see PROCESS.md Triage Workflow).
 ```
 
 ---
@@ -167,7 +173,7 @@ Instructions:
 6. When the story is implemented:
    - Summarize changes
    - Make sure tests are passing
-   - Prepare a PR title and body
+   - Prepare a PR title and body. If the story has source_issue in its frontmatter, the PR description must include "Fixes #<issue_id>" or "Closes #<issue_id>" so the GitHub Issue is linked and auto-closed when the PR is merged (see PROCESS.md Triage Workflow).
    - Remind the user to push and open/refresh the PR
 
 Always:
@@ -206,6 +212,7 @@ Instructions:
 3. Drive a pre-release review:
    - Check that all ACs are addressed
    - Confirm tests are passing
+   - If the story has source_issue, confirm the PR description includes "Fixes #<issue_id>" or "Closes #<issue_id>" so the Issue will be closed when the PR is merged (see PROCESS.md Triage Workflow). If missing, ask the user to add it before merging.
    - Identify open risks or TODOs
 4. Help the user:
    - Approve and merge the PR (you can suggest exact CLI commands if they use git/gh)

--- a/bin/prd.js
+++ b/bin/prd.js
@@ -66,17 +66,21 @@ program
   .action((options) => {
     const chalk = require('chalk');
     const { scanAllStories, getStats } = require('../lib/parser');
+    const { getTriageIssueCount } = require('../lib/github');
 
     const docsPath = resolveDocsPath(options.path);
     try {
       const data = scanAllStories(docsPath);
       const stats = getStats(data.stories);
+      const triageCount = getTriageIssueCount(process.cwd());
 
       console.log('\n' + chalk.bold.cyan('📊 Statistics'));
       console.log(chalk.gray('─'.repeat(40)));
       console.log(`Total:      ${chalk.green.bold(stats.total)}`);
       console.log(`Progress:   ${chalk.yellow.bold(stats.avgProgress + '%')}`);
       console.log(`Blocked:    ${stats.blocked > 0 ? chalk.red.bold(stats.blocked) : chalk.gray('0')}`);
+      const triageDisplay = triageCount === null ? chalk.gray('N/A (gh?)') : chalk.cyan.bold(triageCount);
+      console.log(`Triage:     ${triageDisplay}`);
       console.log('');
     } catch (err) {
       console.error(chalk.red('Error:'), err.message);

--- a/lib/commands/dashboard.js
+++ b/lib/commands/dashboard.js
@@ -4,6 +4,7 @@
 
 const chalk = require('chalk');
 const { scanAllStories, getStats } = require('../parser');
+const { getTriageIssueCount } = require('../github');
 
 const STATUS_CONFIG = {
   backlog: { icon: '📋', color: 'gray', label: 'Backlog' },
@@ -54,7 +55,7 @@ function formatPriority(priority) {
   return chalk[color].bold(priority);
 }
 
-function displaySummary(stats) {
+function displaySummary(stats, triageCount = null) {
   console.log('\n' + chalk.bold.cyan('━'.repeat(60)));
   console.log(chalk.bold.cyan('  📊 PRODUCT STORIES DASHBOARD'));
   console.log(chalk.bold.cyan('━'.repeat(60)) + '\n');
@@ -63,6 +64,8 @@ function displaySummary(stats) {
   console.log(`  Total Stories:     ${chalk.green.bold(stats.total)}`);
   console.log(`  Average Progress:  ${chalk.yellow.bold(stats.avgProgress + '%')}`);
   console.log(`  Blocked:           ${stats.blocked > 0 ? chalk.red.bold(stats.blocked) : chalk.gray('0')}`);
+  const triageDisplay = triageCount === null ? chalk.gray('N/A (gh?)') : chalk.cyan.bold(triageCount);
+  console.log(`  Issues (triage):   ${triageDisplay}`);
 
   console.log('\n' + chalk.white.bold('By Status:'));
   Object.entries(stats.byStatus).forEach(([status, count]) => {
@@ -144,15 +147,19 @@ function dashboard(docsPath, options = {}) {
   try {
     const data = scanAllStories(docsPath);
     const stats = getStats(data.stories);
+    const triageCount = getTriageIssueCount(process.cwd());
 
     if (data.stories.length === 0) {
       console.log(chalk.yellow('\nNo stories found in ' + docsPath));
       console.log(chalk.gray('Create your first story in Cursor: /create "feature" @project/backlog.md\n'));
+      if (triageCount !== null) {
+        console.log(chalk.white('Issues (triage): ') + chalk.cyan.bold(triageCount) + '\n');
+      }
       return;
     }
 
     if (!options.compact) {
-      displaySummary(stats);
+      displaySummary(stats, triageCount);
     }
 
     if (options.compact) {

--- a/lib/github.js
+++ b/lib/github.js
@@ -1,0 +1,28 @@
+/**
+ * GitHub integration helpers (e.g. gh CLI)
+ * Used for triage issue count when gh is available.
+ */
+
+const { execSync } = require('child_process');
+
+/**
+ * Get count of open GitHub Issues with label "triage" in the current repo.
+ * Requires GitHub CLI (gh) to be installed and authenticated.
+ * @param {string} cwd - Working directory (repo root)
+ * @returns {number|null} Count of issues, or null if unavailable (gh missing, not auth, etc.)
+ */
+function getTriageIssueCount(cwd = process.cwd()) {
+  try {
+    const out = execSync('gh issue list --label triage --state open --json number', {
+      encoding: 'utf8',
+      timeout: 8000,
+      cwd
+    });
+    const list = JSON.parse(out || '[]');
+    return Array.isArray(list) ? list.length : 0;
+  } catch (_) {
+    return null;
+  }
+}
+
+module.exports = { getTriageIssueCount };

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -45,6 +45,7 @@ function parseStory(filePath) {
     dependencies: Array.isArray(data.dependencies) ? data.dependencies : [],
     created: data.created || null,
     updated: data.updated || null,
+    source_issue: data.source_issue != null ? (String(data.source_issue).startsWith('#') ? String(data.source_issue) : '#' + String(data.source_issue)) : null,
     filePath
   };
 }

--- a/templates/PROCESS.md
+++ b/templates/PROCESS.md
@@ -67,6 +67,31 @@ product-docs/
 
 ---
 
+## Triage Workflow (GitHub Issues → Stories → PRs)
+
+Use GitHub Issues as the canonical inbox for feedback and feature requests. This workflow keeps Issues, PRDs, and PRs in sync so everyone can see what’s been tackled.
+
+### Labels
+
+| Label | Meaning |
+|-------|---------|
+| **triage** | Issue is in the inbox; not yet converted to a story. |
+| **story-created** | A PRD exists with `source_issue` linking this Issue (story is in backlog or in progress). |
+| **released** (optional) | Issue was addressed; PR merged. You can add this when closing. |
+
+### Lifecycle
+
+1. **Issue created** — Apply label `triage`. (Templates can add it automatically.)
+2. **PRD created from Issue** — In Cursor: `/create from #123 @project/backlog.md`. In the story file, set `source_issue: "#123"` in the YAML frontmatter. Then update the GitHub Issue: remove label `triage`, add label `story-created`.
+3. **PR implements the story** — In the PR description (or title), include `Fixes #123` or `Closes #123` so GitHub links the PR to the Issue.
+4. **PR merged** — GitHub automatically closes the linked Issue. Optionally add label `released` before or at close so the path (open → triage → story-created → closed/released) is visible.
+
+### Visibility
+
+- **CLI:** `prd` and `prd stats` show the count of open Issues with label `triage` (requires [GitHub CLI](https://cli.github.com/) `gh` when run from the repo). If `gh` is not available or not authenticated, the triage count shows as N/A.
+
+---
+
 ## PRD Metadata Format
 
 All PRDs must include YAML frontmatter for dashboard visibility:
@@ -87,12 +112,14 @@ branch: feature/US-027-slug
 pr: 123
 dependencies: [US-019, US-020]
 blockers: []
+source_issue: "#123"   # Optional: GitHub Issue this story came from (traceability)
 ---
 ```
 
 | Field | Values | Description |
 |-------|--------|-------------|
 | `status` | create, approved, dev, done | Current workflow status |
+| `source_issue` | "#123" or null | Optional. GitHub Issue ID this story was created from (for triage workflow). |
 | `phase` | planning, development, testing, review, deployed | Detailed phase within status |
 | `progress` | 0-100 | Percentage complete (AC or task based) |
 | `verified` | true, false, skipped | PRD passed verification |


### PR DESCRIPTION
## Summary

Establishes GitHub Issues as the framework inbox: structured Issue templates (Feature Request, Bug Report), /create from #123, source_issue in parser, triage count in CLI, and full issue lifecycle (triage → story-created → PR Fixes #N → merge closes Issue) documented in PROCESS.md and slash command prompts.

## Related Story

- PRD: product-docs/framework/US-001.md (local; not in repo)
- Resolves: US-001

## Changes

- Added `.github/ISSUE_TEMPLATE/feature_request.md` and `bug_report.md` (Problem Statement, Expected Behavior; label: triage).
- Updated `/create` prompt for Issue-based init and source_issue; reminder to update Issue labels.
- Parser: optional `source_issue` in story metadata.
- New `lib/github.js`: getTriageIssueCount(); dashboard and `prd stats` show triage count (N/A when gh unavailable).
- PROCESS.md: Triage Workflow section (labels, lifecycle, CLI).
- /dev and /release prompts: PR description must include Fixes #<issue_id> when story has source_issue.

## Acceptance Criteria Checklist

- [x] AC1: Issue templates in .github/ISSUE_TEMPLATE
- [x] AC2: /create recognizes Issue refs and uses Issue content
- [x] AC3: Parser supports source_issue
- [x] AC4: PROCESS.md Triage Workflow
- [x] AC5: prd stats / dashboard show triage count
- [x] AC6: PR–Issue link and lifecycle documented and enforced in prompts

## Test Plan

- [x] Manual: Templates render on GitHub; /create from #N prefills from Issue when body is provided.
- [x] Parser: source_issue normalized to #N.
- [x] CLI: prd stats shows Triage line (N/A without gh).
- [ ] With gh: create Issue with label triage, run prd from repo, confirm triage count.